### PR TITLE
document-window now doesn't flicker on load

### DIFF
--- a/src/node_modules/editor/index.js
+++ b/src/node_modules/editor/index.js
@@ -36,6 +36,7 @@ setTimeout(() => {
 }, 128)
 
 let sandbox = new remote.BrowserWindow({
+  show: !!window.localStorage.sandbox,
   width: 450,
   height: 400,
   minWidth: 150,


### PR DESCRIPTION
Before, when the application was launched (and "Document Window Show" was `false`) the document window would flicker and then hide.

Now when the window is instantiated it will either already be hidden or it will show.