### PR TITLE
Enable node harmony flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const {
   BrowserWindow,
   ipcMain
 } = electron
+app.commandLine.appendSwitch('js-flags', '--harmony')
 
 let mainWindow = null
 


### PR DESCRIPTION
By setting the node harmony flag, it will enable **object rest / spread** properties in the current version of Electron (1.8.2) and Node (v8.2.1) upon which **Scratches** currently depends. 

However, when Scratches (via Electron) migrates to Node v8.3+ this will no longer be necessary.

Additionally, with future releases of **Electron**, this flag would continue to enable other Node harmony features, which may or may not be desireable. I couldn't say. 👾 