### PR TITLE
Enforce linting pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,14 +18,18 @@
     "electron-builder": "^20.2.0",
     "electron-icon-maker": "0.0.4",
     "electron-publisher-s3": "^20.2.0",
+    "pre-commit": "^1.2.2",
     "standard": "^10.0.2"
   },
   "scripts": {
+    "start": "electron .",
     "test": "npm run lint",
     "lint": "standard \"**/*.js\"",
+    "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
     "pack": "build",
     "dist": "build --publish=onTagOrDraft"
   },
+  "pre-commit": [ "precommit-msg", "lint" ],
   "author": "Voltra Co. <hello@voltra.co>",
   "license": "MIT",
   "build": {

--- a/src/node_modules/editor/index.js
+++ b/src/node_modules/editor/index.js
@@ -246,12 +246,12 @@ window.events.on('vimMode:toggle', () => {
 })
 
 window.events.on('file:load', () => {
-  remote.dialog.showOpenDialog({ properties: ['openFile'] },  filenames => {
+  remote.dialog.showOpenDialog({ properties: ['openFile'] }, filenames => {
     if (filenames === undefined) return
 
     fs.readFile(filenames[0], 'utf-8', (err, data) => {
       if (err) {
-        remote.dialog.showErrorBox("Load Error", "There was an error loading.") 
+        remote.dialog.showErrorBox('Load Error', 'There was an error loading.')
       } else {
         editor.setValue(data)
       }
@@ -266,7 +266,7 @@ window.events.on('file:save', () => {
     const content = editor.getValue()
     fs.writeFile(filename, content, err => {
       if (err) {
-        remote.dialog.showErrorBox("Save Error", "There was an error saving.")
+        remote.dialog.showErrorBox('Save Error', 'There was an error saving.')
       }
     })
   })


### PR DESCRIPTION
Hi, 

I would like to propose this PR as a way of ensuring that future PRs pass linting checks. 

Much to my embarrassment, I found an earlier PR of mine had introduced linting issues; it just slipped my mind! Therefore, having a way to automate 🤖 linting checks seems like a good idea to me. What do you think?  👈 

Incidentally, to commit the change to package.json I was forced to fix my previous linting mistakes. 

Finally, the `pre-commit` npm package [docs](https://www.npmjs.com/package/pre-commit) also state that it's possible to override the checks if you *really* need to. 🙉 